### PR TITLE
separate arrays with spaces and mandate commas even with decimals

### DIFF
--- a/lib.go
+++ b/lib.go
@@ -317,8 +317,8 @@ func parseAddressArray(s string) []common.Address {
 }
 
 // parseUint256 parses an atto number of tokens, parsing scientific notation if necessary.
-// For example, ".33e4" -> 3300. However, "3300" is perfectly acceptable as well.
-// It also requires that long numbers use commas.
+// For example, ".33e4" -> 3300. However, "3,300" is perfectly acceptable as well.
+// Note that it requires that long numbers use commas.
 func parseUint256(s string) *big.Int {
 	exp := 0
 	var err error
@@ -330,7 +330,7 @@ func parseUint256(s string) *big.Int {
 		s = s[:index]
 	}
 
-	rev := reverse(s)
+	rev := reverse(strings.ReplaceAll(s, ".", ""))
 	for i, val := range rev {
 		if i%4 == 3 {
 			assert(val == ',', "long inputs must contain commas exactly every three digits")
@@ -442,8 +442,7 @@ func keyToHex(key *ecdsa.PrivateKey) string {
 func parseArray(s string) []string {
 	s = strings.ReplaceAll(s, "[", "")
 	s = strings.ReplaceAll(s, "]", "")
-	s = strings.ReplaceAll(s, " ", "")
-	parts := strings.Split(s, ",")
+	parts := strings.Split(s, " ")
 	return parts
 }
 


### PR DESCRIPTION
Previously we added a change that mandated long numbers contain commas every 3 digits. However, this breaks our array parsing, which assumed elements were comma separated. To get around this, I'm changing array parsing to instead separate on space. Additionally, I'm making sure we mandate commas _even after the decimal point_, for clarity. So, this:

`poke Basket.json deploy $ZERO "[$PAX, $TUSD, $USDC]" "[.333333e36, .333333e36, 333334e18]"`

becomes

`poke Basket.json deploy $ZERO "[$PAX $TUSD $USDC]" "[.333,333e36 .333,333e36 333,334e18]"`
